### PR TITLE
Fix versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # project specific files
 third_party
-*blazegraph.jar
 data/
 stanford-corenlp-full-2018-10-05
 test-output
@@ -15,6 +14,9 @@ train-debug-openie/
 openie_output/
 *.props
 transition-amr-parser-0.4.2/
+
+*.ttl
+blazegraph/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -34,7 +34,11 @@ Note that the scripts/install.sh downloads some NLTK corpora. If you already hav
 Note that we use YAML config file to set app specific parameters. To get started, create your own local config file using config_template.yaml file and customize values of different fields if needed and save with name config.yaml.
 
 ## Setup knowledge base
-(1) download the .ttl.zip file from [KG](https://github.com/IBM/AMR-CSLogic/tree/master/KG) and unzip it for uploading to Blazegraph later. As of 15th Dec, we are using UL_KB_V5_PUB.ttl.zip.
+(1) unzip .ttl.zip file from KG folder for uploading to Blazegraph later.
+
+```bash
+unzip KG/UL_KB_V5_PUB.ttl.zip
+```
 
 (2) start a database server with the command
 ```

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,14 +1,16 @@
 # INSTALLATION: amr-verbnet-semantics
 
 ## Create virtual environment
-```
+
+```bash
 conda create -n amr-verbnet python=3.7
 conda activate amr-verbnet
 ```
 
 ## Install dependencies
 If we want to visualize the enhanced AMR graph, we need to install the pygraphviz package, which requires installing graphviz first:
-```
+
+```bash
 # Using Conda
 conda install -c anaconda graphviz
 CONDA_HOME=$(which conda); pip install --global-option=build_ext --global-option="-I{$CONDA_HOME}/envs/amr-verbnet/include" --global-option="-L{$CONDA_HOME}/envs/amr-verbnet/lib" --global-option="-R{$CONDA_HOME}/envs/amr-verbnet/lib" pygraphviz
@@ -21,17 +23,23 @@ pip install pygraphviz
 brew install graphviz
 pip install pygraphviz
 ```
+
 You can know how to install pygraphviz on other environments with 
 [the document](https://pygraphviz.github.io/documentation/stable/install.html).
 
 Next we install our git repository as a standalone python library so that it can be called from other projects. Specifically, it is installed under the project root directory.
-```
+```bash
 bash scripts/install.sh
 ```
 Note that the scripts/install.sh downloads some NLTK corpora. If you already have some existing corpora under ~/nltk-data, please do backup accordingly.
 
 ## Create config file
 Note that we use YAML config file to set app specific parameters. To get started, create your own local config file using config_template.yaml file and customize values of different fields if needed and save with name config.yaml.
+
+```bash
+cp config_template.yaml config.yaml
+nano config.yaml
+```
 
 ## Setup knowledge base
 (1) unzip .ttl.zip file from KG folder for uploading to Blazegraph later.
@@ -41,10 +49,12 @@ unzip KG/UL_KB_V5_PUB.ttl.zip
 ```
 
 (2) start a database server with the command
-```
+
+```bash
 cd blazegraph
-java -server -Xmx32g -jar blazegraph.jar
+java -server -Xmx32g -Djetty.port=9999 -jar blazegraph.jar
 ```
+
 You can see the server through `http://127.0.0.1:9999/blazegraph/`. 
 
 (3) On the ‘namespaces’ tab, create a new namespace with the name you want, e.g. UL_KB_V5_PUB. Make sure you tick ‘inference’ and ‘full text index’  
@@ -57,41 +67,52 @@ You can see the server through `http://127.0.0.1:9999/blazegraph/`.
 <img src="./assets/blazegraph_install_3.jpg">
 
 (6) set the SPARQL_ENDPOINT address in the config.yaml file, e.g.
-```
+
+```yaml
 SPARQL_ENDPOINT: "http://localhost:9999/blazegraph/namespace/UL_KB_V5_PUB"
 ```
 
 ## Download AMR parsing models for local use
 Note that the scripts/install.sh creates `third_party` directory to store the AMR models. To use it locally, you have to download the pre-trained model file for AMR from the following path on CCC. Then you have to unzip the file in `third_party` directory. If you use the default values of AMR_MODEL_CHECKPOINT_PATH and THIRD_PARTY_PATH from the config template, you are good to go. Otherwise, set them accordingly.
-- `/dccstor/ykt-parse/SHARED/MODELS/AMR/transition-amr-parser/amr2.0_v0.4.1_youngsuk_ensemble_destillation.zip`
+ 
+`/dccstor/ykt-parse/SHARED/MODELS/AMR/transition-amr-parser/amr2.0_v0.4.1_youngsuk_ensemble_destillation.zip`
 
 ## Set up the PYTHONPATH environment variable
 All test python code should be called from the project root directory, which is what the PYTHONPATH environment variable should be set to.
-```
+
+```bash
 export PYTHONPATH=.
 ```
 
 ## FLASK server
 If you would like to use FLASK to call the parsing as a web service with the advantage of faster response, set the following in the config.yaml file:
-```
+
+```yaml
 USE_FLASK: true
 ```
+
 To start FLASK server, run
+
+```bash
+export FLASK_APP=./amr_verbnet_semantics/web_app/__init__.py; python -m flask run --host=0.0.0.0 --port=5000
 ```
-export FLASK_APP=./amr_verbnet_semantics/web_app/__init__.py
-python -m flask run --host=0.0.0.0
-```
+
 The Flask logs indicate what URL the service is running on.
 
 To test the service, try a test example:
-```
+
+```bash
 python amr_verbnet_semantics/test/test_service.py
 ```
+
 Otherwise set it to false to call the package directly:
-```
+
+```yaml
 USE_FLASK: false
 ```
+
 and then try a test example:
-```
+
+```bash
 python amr_verbnet_semantics/test/test_local_amr_client.py
 ```

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,5 +1,44 @@
 # INSTALLATION: amr-verbnet-semantics
 
+# CUDA
+
+- Supported CUDA 10.2
+  - Note: `thinc` gives an error with CUDA 11.
+  - <details><summary>Install commands for CUDA 10.2 on Ubuntu 20</summary><div>
+  
+    ```bash
+    # download toolkit from https://developer.nvidia.com/cuda-10.2-download-archive
+    # download cudnn from https://developer.nvidia.com/rdp/cudnn-archive#a-collapse830-102
+    
+    # set gcc-9 priority
+    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90
+    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 90
+    
+    # install gcc-7
+    sudo apt-get install gcc-7 g++-7
+    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100
+    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100
+    
+    # install cuda
+    sudo sh cuda_10.2.89_440.33.01_linux.run
+   
+    # add these paths in .bashrc
+    nano ~/.bashrc
+    # export LD_LIBRARY_PATH=/usr/local/cuda-10.2/lib64:$LD_LIBRARY_PATH
+    # export PATH=/usr/local/cuda-10.2/bin:$PATH
+    
+    # install cudnn
+    sudo dpkg -i cudnn-local-repo-ubuntu1804-8.3.1.22_1.0-1_amd64.deb
+   
+    # check cuda version
+    nvcc --version
+     
+    # if you want to decrease the priority for gcc-7
+    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 70
+    sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 70
+    ```
+    </div></details>
+
 ## Create virtual environment
 
 ```bash

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -133,7 +133,7 @@ USE_FLASK: true
 To start FLASK server, run
 
 ```bash
-export FLASK_APP=./amr_verbnet_semantics/web_app/__init__.py; python -m flask run --host=0.0.0.0 --port=5000
+export FLASK_APP=./amr_verbnet_semantics/web_app/__init__.py; export AMR_LOCAL_SERVICE_PORT=5000; python -m flask run --host=0.0.0.0 --port=5000
 ```
 
 The Flask logs indicate what URL the service is running on.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 Please read [INSTALLATION.md](./INSTALLATION.md)
 
 ## Note
-- how to clear a cache
+- How to clear a cache
   - This implementation uses a cache to speed up the AMR parser. A snapshot is stored on disk to store the cache permanently. The file name of the snapshot takes this format `snapshot.pickle_%Y-%m-%d_%H-%M-%S`. Here is an example of a file name; `snapshot.pickle_2021-10-06_14-52-41`
   - If you want to delete snapshot files, use `bash scripts/remove_snapshot.sh /`. Then please start up the server again to clear a cache. The method is written in [INSTALLATION.md](./INSTALLATION.md). 

--- a/amr_verbnet_semantics/test/test_service.py
+++ b/amr_verbnet_semantics/test/test_service.py
@@ -1,23 +1,27 @@
 """
 Test for services
 """
+import argparse
 import json
 from pprint import pprint
 
 import requests
 
-# host = "10.208.109.152"
-host = "0.0.0.0"
-port = 5000
+parser = argparse.ArgumentParser()
 
-text = "You enter a kitchen."
-# text = "You see a dishwasher and a fridge."
-# text = "Here 's a dining table ."
-# text = "You see a red apple and a dirty plate on the table ."
-# text = "You've entered a kitchen. You see a dishwasher and a fridge. Here's a dining table. You see a dirty plate and a red apple on the table."
+parser.add_argument('--ip', type=str, default='0.0.0.0')
+parser.add_argument('--port', type=int, default=5000)
+parser.add_argument('--text', type=str, default='You enter a kitchen.')
 
-# res = requests.get("http://{}:{}/amr_parsing".format(host, port), params={'text': text})
-res = requests.get("http://{}:{}/verbnet_semantics".format(host, port), params={'text': text})
+args = parser.parse_args()
+
+host = args.ip
+port = args.port
+
+text = args.text
+
+res = requests.get("http://{}:{}/verbnet_semantics".format(host, port),
+                   params={'text': text})
 
 print("\nres.text:")
 print(res.text)
@@ -47,4 +51,3 @@ if "amr_parse" in res:
 
         print("\ngrounded_stmt:")
         print(res["amr_parse"][i]["grounded_stmt_str"])
-

--- a/amr_verbnet_semantics/web_app/__init__.py
+++ b/amr_verbnet_semantics/web_app/__init__.py
@@ -36,9 +36,5 @@ if __name__ != "__main__":
         handler.setFormatter(formatter)
     app.logger.info("Logging handler established")
 
-app.logger.info(70 * "*")
-app.logger.info("  A M R   V E R B N E T   S E R V I C E  ".center(70, "*"))
-app.logger.info(70 * "*")
-
 app.logger.info("Service inititalized!")
 

--- a/app_config.py
+++ b/app_config.py
@@ -2,10 +2,9 @@
 Load configuration from .yaml file.
 """
 import os
+
 import yaml
-
 from amr_verbnet_semantics.utils.format_util import DictObject, to_json
-
 
 config_file_path = os.path.join(os.path.dirname(__file__), "config.yaml")
 if not os.path.exists(config_file_path):
@@ -16,8 +15,10 @@ with open(config_file_path, "r") as f:
 
 config = DictObject(config)
 
+env_port_num = os.environ.get('AMR_LOCAL_SERVICE_PORT', '')
+if env_port_num != '':
+    config.LOCAL_SERVICE_PORT = env_port_num
 
 if __name__ == "__main__":
     print(to_json(config))
     print(config.SPARQL_ENDPOINT)
-

--- a/config.py
+++ b/config.py
@@ -2,8 +2,6 @@
 Config file for FLASK web service.
 """
 import logging
-import os
 
 # Secret for session management
-SECRET_KEY = os.getenv("SECRET_KEY", "sup3r-s3cr3t")
 LOGGING_LEVEL = logging.INFO

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,17 @@
 requests==2.25.1
-nltk==3.6.6
+nltk==3.6.2
 jsonlines==2.0.0
 grpcio==1.37.1
 grpcio-tools==1.37.1
 penman==1.2.0
 fuzzywuzzy==0.17.0
 networkx==2.4
-spacy==3.2.1 #==2.0.12
+#spacy==2.1.0
+spacy==2.0.16
 neuralcoref==3.1
 gensim==3.8.1
 protobuf==3.17.3
 
-numpy
 python-Levenshtein
 flask
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ penman==1.2.0
 fuzzywuzzy==0.17.0
 networkx==2.4
 #spacy==2.1.0
-spacy==2.0.16
+spacy==2.0.12
 neuralcoref==3.1
 gensim==3.8.1
 protobuf==3.17.3

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,6 +14,8 @@ if [[ ${CONDA_DEFAULT_ENV:-''} != amr-verbnet ]]; then
   exit 1
 fi
 
+pip install numpy
+
 echo "** installing packages **"
 pip install -e . # this calls setup.py
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     description='Enhancing AMR with VerbNet semantics',
     author='Zhicheng (Jason) Liang and Dr. Rosario Uceda-Sosa',
     author_email='liangz4@rpi.edu and rosariou@us.ibm.com',
-    url='https://github.com/CognitiveHorizons/AMR-CSLogic',
+    url='https://github.com/IBM/AMR-CSLogic',
     packages=find_packages(include=[
         'amr_verbnet_semantics',
         'amr_verbnet_semantics.*',


### PR DESCRIPTION
These commits are for fixing these errors:

- Do `pip install numpy` in script.sh is for fixing this error

```
$ bash scripts/install.sh
** ensuring latest version of pip is installed **
Requirement already satisfied: pip in /home/daiki/anaconda3/envs/amr-verbnet-v5/lib/python3.7/site-packages (22.0.3)
** installing packages **
Obtaining file:///home/daiki/code/loa-oss/third_party/amr-cslogic
  Preparing metadata (setup.py) ... done
Collecting requests==2.25.1
  Using cached requests-2.25.1-py2.py3-none-any.whl (61 kB)
Collecting nltk==3.6.6
  Using cached nltk-3.6.6-py3-none-any.whl (1.5 MB)
Collecting jsonlines==2.0.0
  Using cached jsonlines-2.0.0-py3-none-any.whl (6.3 kB)
Collecting grpcio==1.37.1
  Using cached grpcio-1.37.1-cp37-cp37m-manylinux2014_x86_64.whl (4.2 MB)
Collecting grpcio-tools==1.37.1
  Using cached grpcio_tools-1.37.1-cp37-cp37m-manylinux2014_x86_64.whl (2.5 MB)
Collecting penman==1.2.0
  Using cached Penman-1.2.0-py3-none-any.whl (43 kB)
Collecting fuzzywuzzy==0.17.0
  Using cached fuzzywuzzy-0.17.0-py2.py3-none-any.whl (13 kB)
Collecting networkx==2.4
  Using cached networkx-2.4-py3-none-any.whl (1.6 MB)
Collecting spacy==3.2.1
  Using cached spacy-3.2.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (6.0 MB)
Collecting neuralcoref==3.1
  Using cached neuralcoref-3.1.tar.gz (571 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 36, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-8qurdep8/neuralcoref_773812ccae8d4476b11e21dd1ce59350/setup.py", line 6, in <module>
          import numpy
      ModuleNotFoundError: No module named 'numpy'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed
```

- Downgrade for `nltk` and `spacy` are fixing these error

```
      /usr/local/cuda-11.0/bin/nvcc -I/home/daiki/anaconda3/envs/amr-verbnet-v5/include/python3.7m -I/tmp/pip-install-rl94dq4n/thinc_606ad439778746d494a1e55be71aca96/include -I/usr/local/cuda-11.0/include -I/home/daiki/anaconda3/envs/amr-verbnet-v5/include/python3.7m -c include/_cuda_shim.cu -o build/temp.linux-x86_64-3.7/include/_cuda_shim.o -arch=sm_30 --ptxas-options=-v -c --compiler-options '-fPIC'
      nvcc fatal   : Value 'sm_30' is not defined for option 'gpu-architecture'
      error: command '/usr/local/cuda-11.0/bin/nvcc' failed with exit status 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for thinc
```